### PR TITLE
Hide red line with 100% on splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,11 +796,11 @@
     {
           QueryLoader2(document.querySelector("body"), 
           {
-              barColor: "#EB004E",
+              barColor: "#111",
               backgroundColor: "#111",
               percentage: true,
               barHeight: 1,
-              minimumTime: 900,
+              minimumTime: 0,
               fadeOutTime: 1000,
               deepSearch: false,
           });


### PR DESCRIPTION
Removes this screen:
![image](https://user-images.githubusercontent.com/12725868/227626797-65ad60e0-fd4b-4d9e-922c-cab017f74e78.png)

Instead, a fade effect is created.